### PR TITLE
Fix docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,3 +4,4 @@ include:
   - services/api/docker-compose.yaml
   - services/reverse-proxy/docker-compose.yaml
   - specs/apis/docker-compose.yaml
+  - services/__template__/docker-compose.yaml

--- a/lib/node-express/src/bin/www.ts
+++ b/lib/node-express/src/bin/www.ts
@@ -15,6 +15,8 @@ import type { Express } from "express";
 
 export const startServer = (app: Express) => {
   // Get port from environment and store in Express
+
+  console.log("process.env.NODE_ENV", process.env.NODE_ENV);
   const port = normalizePort(process.env.PORT || "3000");
   app.set("port", port);
 

--- a/services/__template__/docker-compose.yaml
+++ b/services/__template__/docker-compose.yaml
@@ -1,8 +1,10 @@
 services:
   services-template:
     build:
-      context: .
+      context: ../..
       dockerfile: services/__template__/Dockerfile
+    environment:
+      - NODE_ENV=development
     develop:
       watch:
         - action: sync+restart

--- a/services/api/docker-compose.yaml
+++ b/services/api/docker-compose.yaml
@@ -1,11 +1,12 @@
 services:
   services-api:
+    volumes:
+      - ../../dbs/main/data:/app/dbs/main/data
     build:
       context: ../..
-      dockerfile: ./services/api/Dockerfile
+      dockerfile: services/api/Dockerfile
     environment:
       - NODE_ENV=development
-    command: npm start
     develop:
       watch:
         - action: sync+restart

--- a/services/api/docker-compose.yaml.template
+++ b/services/api/docker-compose.yaml.template
@@ -1,8 +1,4 @@
 services:
   services-api:
-    build:
-      context: ../..
-      dockerfile: ./services/api/Dockerfile
-    environment:
-      - NODE_ENV=development
-    command: npm start
+    volumes:
+      - ../../dbs/main/data:/app/dbs/main/data

--- a/services/auth/docker-compose.yaml
+++ b/services/auth/docker-compose.yaml
@@ -1,13 +1,12 @@
 services:
   services-auth:
-    build:
-      context: ../..
-      dockerfile: ./services/auth/Dockerfile
     volumes:
       - ../../dbs/auth/data:/app/dbs/auth/data
+    build:
+      context: ../..
+      dockerfile: services/auth/Dockerfile
     environment:
       - NODE_ENV=development
-    command: npm start
     develop:
       watch:
         - action: sync+restart

--- a/services/auth/docker-compose.yaml.template
+++ b/services/auth/docker-compose.yaml.template
@@ -1,10 +1,4 @@
 services:
   services-auth:
-    build:
-      context: ../..
-      dockerfile: ./services/auth/Dockerfile
     volumes:
       - ../../dbs/auth/data:/app/dbs/auth/data
-    environment:
-      - NODE_ENV=development
-    command: npm start

--- a/tools/__tests__/generate-docker.test.ts
+++ b/tools/__tests__/generate-docker.test.ts
@@ -113,9 +113,7 @@ describe("generateDockerCompose", () => {
       io,
     });
     const parsed = yaml.parse(compose);
-    expect(parsed.services.api.environment).toEqual({
-      NODE_ENV: "development",
-    });
+    expect(parsed.services.api.environment).toContainEqual("PORT=4000");
   });
   it("should handle template parsing errors", () => {
     const project = readProject("/saf/package.json", io);
@@ -129,5 +127,25 @@ describe("generateDockerCompose", () => {
         io,
       })
     ).toThrow();
+  });
+  it("should add default environment variables if not already set", () => {
+    const project = readProject("/saf/package.json", io);
+    const compose = generateDockerCompose("/saf/services/api/package.json", {
+      project,
+      io,
+    });
+    const parsed = yaml.parse(compose);
+    expect(parsed.services.api.environment).toContainEqual(
+      "NODE_ENV=development"
+    );
+  });
+  it("should set build context if not set", () => {
+    const project = readProject("/saf/package.json", io);
+    const compose = generateDockerCompose("/saf/services/api/package.json", {
+      project,
+      io,
+    });
+    const parsed = yaml.parse(compose);
+    expect(parsed.services.api.build.context).toBe("../..");
   });
 });

--- a/tools/__tests__/mocks.ts
+++ b/tools/__tests__/mocks.ts
@@ -17,13 +17,7 @@ export const volumeJson = {
   "/saf/services/api/docker-compose.yaml.template": JSON.stringify({
     services: {
       api: {
-        build: {
-          context: ".",
-          dockerfile: "services/api/Dockerfile",
-        },
-        environment: {
-          NODE_ENV: "development",
-        },
+        environment: ["PORT=4000"],
       },
     },
   }),

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -121,3 +121,12 @@ export function getRelativePath(packageJsonPath: string, project: Project) {
   const relativePath = path.relative(rootDir, packageJsonPath);
   return relativePath.replace(/\\/g, "/");
 }
+
+export function getRelativePathBetween(from: string, to: string): string {
+  // If paths are files, use their parent directories
+  const fromDir = path.extname(from) ? path.dirname(from) : from;
+  const toDir = path.extname(to) ? path.dirname(to) : to;
+
+  // Calculate relative path and normalize slashes
+  return path.relative(fromDir, toDir).replace(/\\/g, "/");
+}


### PR DESCRIPTION
The __template__ service wasn't working, so I made it such that it works when no docker-compose.yaml.template is provided.

I then also took the opportunity to trim down what was in the other docker-compose.yaml.template files and updated the script to still work in those scenarios as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Enhanced container configurations now include additional service templates and persistent volume mapping for improved deployment and data persistence.
- Refactor
	- Streamlined startup settings for API and authentication services, removing legacy commands.
	- Improved logging to display current environment settings and configured build contexts for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->