### PR TITLE
Add requests unit tests

### DIFF
--- a/clients/requests/auth.test.ts
+++ b/clients/requests/auth.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createApp } from "vue";
+import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
+import { useLogin, useLogout, useRegister } from "./auth";
+import { client } from "./client";
+
+// Mock the client
+vi.mock("./client", () => ({
+  client: {
+    POST: vi.fn(),
+  },
+}));
+
+function withVueQuery(composable: () => unknown) {
+  let result;
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  const app = createApp({
+    setup() {
+      result = composable();
+      return () => {};
+    },
+  });
+
+  app.use(VueQueryPlugin, { queryClient });
+  app.mount(document.createElement("div"));
+
+  return [result, app] as const;
+}
+
+describe("auth requests", () => {
+  const mockPOST = client.POST as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockPOST.mockClear();
+  });
+
+  describe("useLogin", () => {
+    const validCredentials = {
+      email: "test@example.com",
+      password: "password123",
+    };
+
+    it("should make a POST request to /auth/login with credentials", async () => {
+      const mockResponse = { data: { token: "mock-token" }, error: null };
+      mockPOST.mockResolvedValueOnce(mockResponse);
+
+      const [result, app] = withVueQuery(() => useLogin());
+      await result.mutateAsync(validCredentials);
+      app.unmount();
+
+      expect(mockPOST).toHaveBeenCalledWith("/auth/login", {
+        body: validCredentials,
+      });
+    });
+
+    it("should throw error when request fails", async () => {
+      const mockError = { message: "Invalid credentials" };
+      mockPOST.mockResolvedValueOnce({ error: mockError });
+
+      const [result, app] = withVueQuery(() => useLogin());
+      await expect(result.mutateAsync(validCredentials)).rejects.toEqual(
+        mockError,
+      );
+      app.unmount();
+    });
+  });
+
+  describe("useLogout", () => {
+    it("should make a POST request to /auth/logout", async () => {
+      mockPOST.mockResolvedValueOnce({ error: null });
+
+      const [result, app] = withVueQuery(() => useLogout());
+      await result.mutateAsync();
+      app.unmount();
+
+      expect(mockPOST).toHaveBeenCalledWith("/auth/logout");
+    });
+
+    it("should throw error when request fails", async () => {
+      const mockError = { message: "Logout failed" };
+      mockPOST.mockResolvedValueOnce({ error: mockError });
+
+      const [result, app] = withVueQuery(() => useLogout());
+      await expect(result.mutateAsync()).rejects.toEqual(mockError);
+      app.unmount();
+    });
+  });
+
+  describe("useRegister", () => {
+    const validRegistration = {
+      email: "test@example.com",
+      password: "password123",
+      name: "Test User",
+    };
+
+    it("should make a POST request to /auth/register with user data", async () => {
+      const mockResponse = { data: { token: "mock-token" }, error: null };
+      mockPOST.mockResolvedValueOnce(mockResponse);
+
+      const [result, app] = withVueQuery(() => useRegister());
+      await result.mutateAsync(validRegistration);
+      app.unmount();
+
+      expect(mockPOST).toHaveBeenCalledWith("/auth/register", {
+        body: validRegistration,
+      });
+    });
+
+    it("should throw error when request fails", async () => {
+      const mockError = { message: "Registration failed" };
+      mockPOST.mockResolvedValueOnce({ error: mockError });
+
+      const [result, app] = withVueQuery(() => useRegister());
+      await expect(result.mutateAsync(validRegistration)).rejects.toEqual(
+        mockError,
+      );
+      app.unmount();
+    });
+  });
+});

--- a/clients/requests/auth.test.ts
+++ b/clients/requests/auth.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createApp } from "vue";
-import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
 import { useLogin, useLogout, useRegister } from "./auth";
 import { client } from "./client";
+import { withVueQuery } from "./test-utils";
 
 // Mock the client
 vi.mock("./client", () => ({
@@ -10,29 +9,6 @@ vi.mock("./client", () => ({
     POST: vi.fn(),
   },
 }));
-
-function withVueQuery(composable: () => unknown) {
-  let result;
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      mutations: {
-        retry: false,
-      },
-    },
-  });
-
-  const app = createApp({
-    setup() {
-      result = composable();
-      return () => {};
-    },
-  });
-
-  app.use(VueQueryPlugin, { queryClient });
-  app.mount(document.createElement("div"));
-
-  return [result, app] as const;
-}
 
 describe("auth requests", () => {
   const mockPOST = client.POST as ReturnType<typeof vi.fn>;

--- a/clients/requests/auth.ts
+++ b/clients/requests/auth.ts
@@ -7,7 +7,6 @@ export const useLogin = () => {
     mutationFn: async (body: RequestSchema<"loginUser">) => {
       const { data, error } = await client.POST("/auth/login", { body });
       if (error) {
-        console.log(error);
         throw error;
       }
       return data;
@@ -20,7 +19,6 @@ export const useLogout = () => {
     mutationFn: async () => {
       const { error } = await client.POST("/auth/logout");
       if (error) {
-        console.log(error);
         throw error;
       }
     },
@@ -34,7 +32,6 @@ export const useRegister = () => {
         body,
       });
       if (error) {
-        console.log(error);
         throw error;
       }
 

--- a/clients/requests/test-utils.ts
+++ b/clients/requests/test-utils.ts
@@ -1,15 +1,23 @@
 import { createApp } from "vue";
 import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
 
-export function withVueQuery(composable: () => unknown) {
+export function withVueQuery(
+  composable: () => unknown,
+  queryClient?: QueryClient,
+) {
   let result;
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      mutations: {
-        retry: false,
+  const client =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: {
+        mutations: {
+          retry: false,
+        },
+        queries: {
+          retry: false,
+        },
       },
-    },
-  });
+    });
 
   const app = createApp({
     setup() {
@@ -18,8 +26,8 @@ export function withVueQuery(composable: () => unknown) {
     },
   });
 
-  app.use(VueQueryPlugin, { queryClient });
+  app.use(VueQueryPlugin, { queryClient: client });
   app.mount(document.createElement("div"));
 
-  return [result, app] as const;
+  return [result, app, client] as const;
 }

--- a/clients/requests/test-utils.ts
+++ b/clients/requests/test-utils.ts
@@ -1,0 +1,25 @@
+import { createApp } from "vue";
+import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
+
+export function withVueQuery(composable: () => unknown) {
+  let result;
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  const app = createApp({
+    setup() {
+      result = composable();
+      return () => {};
+    },
+  });
+
+  app.use(VueQueryPlugin, { queryClient });
+  app.mount(document.createElement("div"));
+
+  return [result, app] as const;
+}

--- a/clients/requests/testing.md
+++ b/clients/requests/testing.md
@@ -1,0 +1,176 @@
+# Testing Vue Query Hooks
+
+This document explains how to write unit tests for Vue Query hooks in our application, based on the patterns established in `auth.test.ts` and `todos.test.ts`.
+
+## Setup
+
+### Test Utils
+
+We use a helper function `withVueQuery` (from `test-utils.ts`) to properly set up the Vue Query context for testing:
+
+```typescript
+function withVueQuery(composable: () => unknown) {
+  let result;
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  const app = createApp({
+    setup() {
+      result = composable();
+      return () => {};
+    },
+  });
+
+  app.use(VueQueryPlugin, { queryClient });
+  app.mount(document.createElement("div"));
+
+  return [result, app] as const;
+}
+```
+
+### Mocking HTTP Client
+
+Mock the client at the start of your test file:
+
+```typescript
+vi.mock("./client", () => ({
+  client: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+```
+
+## Writing Tests
+
+### 1. Testing Query Hooks
+
+For hooks that fetch data (using `useQuery`):
+
+```typescript
+describe("useMyQuery", () => {
+  it("should fetch data", async () => {
+    // 1. Mock the response
+    const mockData = {
+      /* your mock data */
+    };
+    mockGET.mockResolvedValueOnce({ data: mockData });
+
+    // 2. Set up the query
+    const [result, app] = withVueQuery(() => useMyQuery());
+
+    // 3. Wait for the query to complete
+    await result.suspense();
+
+    // 4. Clean up
+    app.unmount();
+
+    // 5. Assert
+    expect(mockGET).toHaveBeenCalledWith("/your-endpoint");
+    expect(result.data.value).toEqual(mockData);
+  });
+
+  it("should handle null response", async () => {
+    mockGET.mockResolvedValueOnce({ data: null });
+    // ... similar pattern
+  });
+});
+```
+
+### 2. Testing Mutation Hooks
+
+For hooks that modify data (using `useMutation`):
+
+```typescript
+describe("useMyMutation", () => {
+  it("should perform mutation", async () => {
+    // 1. Mock the response
+    const mockResponse = {
+      /* your mock response */
+    };
+    mockPOST.mockResolvedValueOnce({ data: mockResponse });
+
+    // 2. Set up the mutation
+    const [result, app] = withVueQuery(() => useMyMutation());
+
+    // 3. Execute the mutation
+    const response = await result.mutateAsync(mutationData);
+
+    // 4. Clean up
+    app.unmount();
+
+    // 5. Assert
+    expect(mockPOST).toHaveBeenCalledWith("/your-endpoint", {
+      body: mutationData,
+    });
+    expect(response).toEqual(mockResponse);
+  });
+
+  it("should handle errors", async () => {
+    mockPOST.mockResolvedValueOnce({ data: null });
+    const [result, app] = withVueQuery(() => useMyMutation());
+
+    await expect(result.mutateAsync(mutationData)).rejects.toThrow(
+      "Expected error message",
+    );
+
+    app.unmount();
+  });
+});
+```
+
+## Best Practices
+
+1. **Clean Up**: Always call `app.unmount()` after your tests to prevent memory leaks.
+
+2. **Mock Clearing**: Clear mocks in `beforeEach` to ensure clean state:
+
+   ```typescript
+   beforeEach(() => {
+     mockGET.mockClear();
+     mockPOST.mockClear();
+     // etc...
+   });
+   ```
+
+3. **Type Safety**: Use proper typing for your mock data and responses to catch type errors early.
+
+4. **Error Testing**: Always include error cases to ensure proper error handling.
+
+5. **Async/Await**: Use `async/await` with:
+   - `result.suspense()` for queries
+   - `result.mutateAsync()` for mutations
+
+## Examples
+
+See complete examples in:
+
+- `auth.test.ts` - Testing authentication mutations
+- `todos.test.ts` - Testing both queries and mutations for a CRUD interface
+
+## Common Patterns
+
+1. **Query Testing**:
+
+   - Test successful data fetching
+   - Test empty/null responses
+   - Test error handling
+
+2. **Mutation Testing**:
+
+   - Test successful operations
+   - Test error cases
+   - Verify correct endpoint and payload
+   - Test response handling
+
+3. **Setup/Teardown**:
+   - Mock HTTP methods
+   - Clear mocks between tests
+   - Clean up Vue instances

--- a/clients/requests/todos.test.ts
+++ b/clients/requests/todos.test.ts
@@ -40,7 +40,6 @@ describe("todo requests", () => {
       app.unmount();
 
       expect(mockGET).toHaveBeenCalledWith("/todos");
-      console.log(Object.keys(result));
       expect(result.data.value).toEqual(mockTodos);
     });
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -4,9 +4,10 @@ Rough order of development
 
 ### Backlog
 
-- Set up the remaining SUSI flows
-- Add FE unit tests
-- Add E2E tests
+- Add unit tests to /requests
+- Move to sub-domains, using docker.localhost
+- Add playwright tests
+- Add GitHub actions for tests
 - Add forgot email flow
 - Add verify email flow
 


### PR DESCRIPTION
Add unit tests to clients/requests. Now everything in clients has a path to being unit tested. The only things that are not tested are the mostly stub vue pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded test coverage for authentication and task management operations, ensuring more robust error handling and state management.
  - Introduced enhanced testing utilities to simulate network responses and manage query behaviors reliably.
  
- **Documentation**
  - Updated internal development guidelines to reflect refinements in testing procedures, workflow, and infrastructure practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->