### PR TITLE
Add admin emails

### DIFF
--- a/deploy/instance/docker-compose.prod-local.yaml
+++ b/deploy/instance/docker-compose.prod-local.yaml
@@ -9,6 +9,10 @@ services:
       file: remote-assets/docker-compose.prod.yaml
       service: auth
     volumes: !override []
+    environment:
+      # playwright depends on these. 
+      # TODO: Set this somehow in the e2e folder
+      - ADMIN_EMAILS=admin-firefox@example.com,admin-chromium@example.com
   caddy:
     extends:
       file: remote-assets/docker-compose.prod.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -974,7 +974,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
       "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "cookie": "^0.7.2"
@@ -984,7 +983,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
       "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "statuses": "^2.0.1"
@@ -994,7 +992,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
       "integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@types/tough-cookie": "^4.0.5",
@@ -1005,7 +1002,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.33",
@@ -2384,7 +2380,6 @@
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.8.tgz",
       "integrity": "sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.9",
@@ -2406,7 +2401,6 @@
       "version": "10.1.9",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.9.tgz",
       "integrity": "sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.11",
@@ -2434,7 +2428,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2444,14 +2437,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/core/node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2464,7 +2455,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2479,7 +2469,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2492,7 +2481,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2507,7 +2495,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
       "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2517,7 +2504,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
       "integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2657,7 +2643,6 @@
       "version": "0.37.6",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.6.tgz",
       "integrity": "sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@open-draft/deferred-promise": "^2.2.0",
@@ -2716,14 +2701,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
       "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@open-draft/logger": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
       "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-node-process": "^1.2.0",
@@ -2734,7 +2717,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@opentelemetry/api": {
@@ -3757,7 +3739,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/cookiejar": {
@@ -3975,7 +3956,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.5.tgz",
       "integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/stylis": {
@@ -4010,7 +3990,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
@@ -5034,7 +5013,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
@@ -5050,7 +5028,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "devOptional": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -5762,7 +5739,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -7937,7 +7913,6 @@
       "version": "16.10.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
       "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -8061,7 +8036,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/hexoid": {
@@ -8365,7 +8339,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-number": {
@@ -9423,7 +9396,6 @@
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.3.tgz",
       "integrity": "sha512-+mycXv8l2fEAjFZ5sjrtjJDmm2ceKGjrNbBr1durRg6VkU9fNUE/gsmQ51hWbHqs+l35W1iM+ZsmOD9Fd6lspw==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -9468,7 +9440,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9478,7 +9449,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -9493,21 +9463,18 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/msw/node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/msw/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -9522,7 +9489,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9535,7 +9501,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -9553,7 +9518,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -9641,7 +9605,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -10142,7 +10105,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/p-limit": {
@@ -10653,7 +10615,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -10700,7 +10661,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -10984,7 +10944,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -12204,7 +12163,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/string_decoder": {
@@ -13446,7 +13404,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -13530,7 +13487,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "querystringify": "^2.1.1",
@@ -15536,7 +15492,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
       "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -15634,6 +15589,7 @@
     "saflib/node-express": {
       "name": "@saflib/node-express",
       "dependencies": {
+        "ajv": "^8.0.0",
         "cors": "^2.0.0",
         "dotenv": "^16.0.0",
         "express": "^4.0.0",
@@ -15699,11 +15655,9 @@
         "@saflib/vue-spa": "*",
         "@vue/test-utils": "^2.0.0",
         "jsdom": "^26.0.0",
+        "msw": "^2.0.0",
         "sass-embedded": "^1.0.0",
         "vite-plugin-vuetify": "^2.0.0"
-      },
-      "devDependencies": {
-        "msw": "^2.0.0"
       }
     },
     "services/api": {

--- a/tests/e2e/auth-scopes.spec.ts
+++ b/tests/e2e/auth-scopes.spec.ts
@@ -37,48 +37,47 @@ test.describe("Auth Scopes", () => {
     await page.locator("form").getByRole("button").click();
     await expect(page.getByText(todoText)).toBeVisible();
 
-    // Verify delete all button is not visible for regular users
+    // Verify delete all button doesn't work for regular users
     await page.getByRole("button", { name: "Delete All Todos" }).click();
     await expect(page.getByText(todoText)).toBeVisible();
   });
 
-  // test("admin user can delete all todos", async ({ page }) => {
-  //   // Register an admin user (using admin.*@email.com pattern)
-  //   await page.goto("http://docker.localhost/auth/register");
-  //   const randomString = getRandomString(10);
-  //   const adminEmail = `admin.${randomString}@email.com`;
-  //   await page.getByRole("textbox", { name: "Email address" }).fill(adminEmail);
-  //   await page
-  //     .getByRole("textbox", { name: "Enter your password" })
-  //     .fill("asdfasdf");
-  //   await page
-  //     .getByRole("textbox", { name: "Confirm your password" })
-  //     .fill("asdfasdf");
-  //   await page.getByRole("button", { name: "Register" }).click();
+  test("admin user can delete all todos", async ({ page }, workerInfo) => {
+    // Register an admin user (using admin.*@email.com pattern)
+    await page.goto("http://docker.localhost/auth/register");
+    const adminEmail = `admin-${workerInfo.project.name}@example.com`;
+    await page.getByRole("textbox", { name: "Email address" }).fill(adminEmail);
+    await page
+      .getByRole("textbox", { name: "Enter your password" })
+      .fill("asdfasdf");
+    await page
+      .getByRole("textbox", { name: "Confirm your password" })
+      .fill("asdfasdf");
+    await page.getByRole("button", { name: "Register" }).click();
 
-  //   // Verify we're on the todo list page
-  //   await expect(
-  //     page.getByRole("heading", { name: "Todo List" }),
-  //   ).toBeVisible();
+    // Verify we're on the todo list page
+    await expect(
+      page.getByRole("heading", { name: "Todo List" }),
+    ).toBeVisible();
 
-  //   // Add a todo
-  //   const todoText = getRandomString(10);
-  //   await page.getByRole("textbox", { name: "New Todo New Todo" }).click();
-  //   await page
-  //     .getByRole("textbox", { name: "New Todo New Todo" })
-  //     .fill(todoText);
-  //   await page.locator("form").getByRole("button").click();
-  //   await expect(page.getByText(todoText)).toBeVisible();
+    // Add a todo
+    const todoText = getRandomString(10);
+    await page.getByRole("textbox", { name: "New Todo New Todo" }).click();
+    await page
+      .getByRole("textbox", { name: "New Todo New Todo" })
+      .fill(todoText);
+    await page.locator("form").getByRole("button").click();
+    await expect(page.getByText(todoText)).toBeVisible();
 
-  //   // Verify delete all button is visible for admin users
-  //   await expect(
-  //     page.getByRole("button", { name: "Delete All Todos" }),
-  //   ).toBeVisible();
+    // Verify delete all button is visible for admin users
+    await expect(
+      page.getByRole("button", { name: "Delete All Todos" }),
+    ).toBeVisible();
 
-  //   // Test the delete all functionality
-  //   await page.getByRole("button", { name: "Delete All Todos" }).click();
+    // Test the delete all functionality
+    await page.getByRole("button", { name: "Delete All Todos" }).click();
 
-  //   // Verify todos are deleted (assuming there's a message or empty state)
-  //   await expect(page.getByText("No todos yet")).toBeVisible();
-  // });
+    // Verify todos are deleted (assuming there's a message or empty state)
+    await expect(page.getByText("No todos yet")).toBeVisible();
+  });
 });


### PR DESCRIPTION
Testing and adopting https://github.com/sderickson/saflib/pull/7. Mainly just re-enables the admin-scope playwright test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chore**
  - Updated a subproject reference to integrate recent modifications and enhancements.
- **New Features**
  - Introduced an environment variable `ADMIN_EMAILS` for the `auth` service to support Playwright requirements.
- **Tests**
  - Clarified test cases for user roles regarding todo deletion functionality.
  - Reactivated and enhanced admin user test with dynamic email generation for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->